### PR TITLE
商品詳細表示機能　実装

### DIFF
--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -52,7 +52,7 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:category_id, Category.all, :id,, :name, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -132,17 +132,16 @@
           <%= link_to item_path(item.id) do %>
             <div class= 'item-img-content'> 
                <%= image_tag item.image, class: 'item-img' if item.image.attached? %>
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+    
 
-          <%# 商品が売れていればsold outを表示しましょう %>
+        
           <div class='sold-out'>
           <% if item.purchase.present? %>
           <div class='sold-out'>
             <span><%= "Sold Out!!" %></span>
           </div>
           <%end%>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
+        
         </div>
          <div class='item-info'>
             <h3 class='item-name'>
@@ -161,10 +160,9 @@
           <%end%>
       </li>
       <% else %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      
 
-      <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -183,13 +181,12 @@
         <% end %>
       </li>
       <% end %>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# /商品がない場合のダミー %>
+   
     </ul>
   </div>
 
 
-  <%# /商品一覧 %>
+
 </div>
 <div class='purchase-btn'>
   <span class='purchase-btn-text'>出品する</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,14 +28,13 @@
     </div>
 
   
-  <% user_signed_in? && current_user.id == @item.user_id %>
+  <% if user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
-
-
+    <%else%>
     <%= link_to '購入画面に進む', item_purchases_path(@item.id),class:"item-red-btn"%>
-  
+  <%end%>
 
 
    


### PR DESCRIPTION
What（どのような実装をしているのか）
商品詳細表示機能の実装

Why（なぜこの実装が必要なのか）
出品者の商品編集と削除、ログアウト状態でも詳細表示が見れて商品購入につながりやすい

ログアウト状態でも商品詳細ページを閲覧できること
https://gyazo.com/42e4bb68a48ca743b0d40fd88365f9d2

出品者にしか商品の編集・削除のリンクが踏めないようになっていること
https://gyazo.com/4bd4743be40d69d80019455de39e5fcf

出品者以外（且つログインしたユーザー）のみ商品購入のリンクが踏めること
https://gyazo.com/bbaf2e0c24e217fa46febffcf95c80bb

商品出品時に登録した情報が見られるようになっていること
https://gyazo.com/38d1405fd45c6902a665c0c6bdfa2e6f

ご確認よろしくお願いします。

