### PR TITLE
商品編集機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -39,8 +39,10 @@ class ItemsController < ApplicationController
   end
 
   def update
-    if @item.update(item_params)
-      render :show
+    @item = Item.find(params[:id])
+    @item.update(item_params)
+      if @item.save
+        redirect_to item_path
     else
       render :edit
     end
@@ -59,4 +61,5 @@ class ItemsController < ApplicationController
   def item_set
     @item = Item.find(params[:id])
   end
+
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   # skip_before_action :authenticate_user!  ,only: [:show, :index]
-  before_action :item_set, only: [:edit, :show]
+  before_action :item_set, only: [:edit, :show, :update]
   before_action :move_to_index, except: [:index, :show]
 
 
@@ -39,9 +39,7 @@ class ItemsController < ApplicationController
   end
 
   def update
-    @item = Item.find(params[:id])
-    @item.update(item_params)
-      if @item.save
+    if @item.update(item_params)
         redirect_to item_path
     else
       render :edit

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,7 +7,9 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with (model: @item, local: true) do |f| %>
+
+    
+    <%= form_with(model: @item, local: true) do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%= render 'shared/error_messages', model: f.object %>
@@ -18,7 +20,7 @@ app/assets/stylesheets/items/new.css %>
       <div class="weight-bold-text">
         出品画像
         <span class="indispensable">必須</span>
-      </div>
+      </div> 
       <div class="click-upload">
         <p>
           クリックしてファイルをアップロード


### PR DESCRIPTION
What
商品編集機能の実装

Why
状況に合わせ出品内容を流動的に変更できるようにするため

商品情報（商品画像・商品名・商品の状態など）を変更できること

何も編集せずに更新をしても画像無しの商品にならない
出品者だけが編集ページに遷移できること
商品出品時とほぼ同じUIで編集機能が実装できること
商品名やカテゴリーの情報など、すでに登録されている商品情報は編集画面を開いた時点で表示されること（画像に関しては、表示されない状態で良い）
https://gyazo.com/e2b8d4de0430b6c6ad1e60bce0170767


エラーハンドリングができていること（適切では無い値が入力された場合、情報は保存されず、エラーメッセージを出力させる）
https://gyazo.com/a34872bcbc371472eb272fde12b96bcd

よろしくお願いします。